### PR TITLE
Update banner method

### DIFF
--- a/src/components/BacklogTable.vue
+++ b/src/components/BacklogTable.vue
@@ -31,6 +31,7 @@
 </template>
     
 <script>
+import { getBannerUrl, getGames } from "@/scripts/utils";
   export default {
     name: "BacklogTable",
     props: ['gameData'],
@@ -44,29 +45,7 @@
   
     },
     methods: {
-      getBannerUrl(data) {
-        var banner;
-        if(data.steamId != null && data.steamId != ""){
-          var id = data.steamId;
-          banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
-        }else{
-          var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-          banner = "/game_assets/banners/"+title+"_banner.png";
-        }
-        return banner;
-      },
-      getGamePageUrl(data) {
-        var gamePage;
-        if(data.steamId != null && data.steamId != ""){
-          var id = data.steamId;
-          var title = data.title.replace(/ /g,"_").replace(/'/g, '');
-          gamePage = "https://store.steampowered.com/app/"+id+"/"+title+"/";
-        }else{
-          var title = data.title.toLowerCase().replace(/ /g,"-").replace(/'/g, '');
-          gamePage = "https://store.epicgames.com/en-US/p/"+title;
-        }
-        return gamePage;
-      },
+      getBannerUrl,
       getHLTBPageUrl(data) {
         var title = data.title.replace(/— /g,"").replace(/- /g,"").replace(/ /g,"%2520").replace(/'/g, '').replace(/:/g, '').replace(/™/g, '').toLowerCase();
         var hLTBPage = "https://howlongtobeat.com/?q="+title;

--- a/src/components/CurrentlyPlaying.vue
+++ b/src/components/CurrentlyPlaying.vue
@@ -19,7 +19,7 @@
 </template>
   
 <script>
-
+import { getBannerUrl, getGamePageUrl, getGames } from "@/scripts/utils";
 export default {
   name: "GameView",
   props: ['gameData'],
@@ -33,29 +33,8 @@ export default {
 
   },
   methods: {
-    getBannerUrl(data) {
-      var banner;
-      if(data.steamId != null && data.steamId != ""){
-        var id = data.steamId;
-        banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
-      }else{
-        var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-        banner = "/game_assets/banners/"+title+"_banner.png";
-      }
-      return banner;
-    },
-    getGamePageUrl(data) {
-      var gamePage;
-      if(data.steamId != null && data.steamId != ""){
-        var id = data.steamId;
-        var title = data.title.replace(/ /g,"_").replace(/'/g, '');
-        gamePage = "https://store.steampowered.com/app/"+id+"/"+title+"/";
-      }else{
-        var title = data.title.toLowerCase().replace(/ /g,"-").replace(/'/g, '');
-        gamePage = "https://store.epicgames.com/en-US/p/"+title;
-      }
-      return gamePage;
-    },
+    getBannerUrl,
+    getGamePageUrl,
   },
 };
 

--- a/src/components/GameTable.vue
+++ b/src/components/GameTable.vue
@@ -86,7 +86,7 @@
                     <span>{{ slotProps.data.title }}</span>
                     <p-button v-if="slotProps.data.steamId" severity="info" text link aria-label="Steam" v-tooltip.bottom="{ value: 'Steam Page' }">
                       <template #icon>
-                        <a :href="getSteamPageUrl(slotProps.data)" target="_blank">
+                        <a :href="getGamePageUrl(slotProps.data)" target="_blank">
                           <font-awesome-icon class="text-2xl" icon="fa-brands fa-steam" color="grey" />
                         </a>
                       </template>
@@ -129,6 +129,7 @@
   
 <script>
   import { FilterMatchMode, FilterOperator } from '@primevue/core/api'
+  import { getBannerUrl, getGamePageUrl, getIconUrl } from "@/scripts/utils";
   
   export default {
     name: "GameView",
@@ -303,38 +304,9 @@
 
         }
       },
-      getIconUrl(data) {
-        var icon;
-        if(data.steamIcon != null && data.steamIcon != ""){
-          var id = data.steamId;
-          var hash = data.steamIcon;
-          icon = "http://media.steampowered.com/steamcommunity/public/images/apps/"+id+"/"+hash+".jpg";
-        }else{
-          var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-          icon = "/game_assets/icons/"+title+"_icon.png";
-        }
-        return icon;
-      },
-      getBannerUrl(data) {
-        var banner;
-        if(data.steamId != null && data.steamId != ""){
-          var id = data.steamId;
-          banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
-        }else{
-          var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-          banner = "/game_assets/banners/"+title+"_banner.png";
-        }
-        return banner;
-      },
-      refresh() {
-        this.$emit('refresh-data');
-      },
-      getSteamPageUrl(data) {
-        var id = data.steamId;
-        var title = data.title.replace(/ /g,"_").replace(/'/g, '');
-        var steamPage = "https://store.steampowered.com/app/"+id+"/"+title+"/";
-        return steamPage;
-      },
+      getIconUrl,
+      getBannerUrl,
+      getGamePageUrl,
       getMetacriticPageUrl(data) {
         var title = data.title.replace(/— /g,"").replace(/- /g,"").replace(/ /g,"-").replace(/'/g, '').replace(/:/g, '').replace(/™/g, '').toLowerCase();
         var metacriticPage = "https://www.metacritic.com/game/"+title+"/";
@@ -354,6 +326,9 @@
         if(gameData.title != ""){
           this.showReviewDialogVal = true;
         }
+      },
+      refresh() {
+        this.$emit('refresh-data');
       },
     },
   };

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -1,0 +1,17 @@
+// function for fetching the steam banner url
+function getBannerUrl(data) {
+    var banner;
+    
+    // if there's a steam id, then fetch the banner image from steam
+    if(data.steamId != null && data.steamId != ""){
+        var id = data.steamId;
+        banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
+    }else{
+        // if it's not a steam game, grab the image locally
+        var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
+        banner = "/game_assets/banners/"+title+"_banner.png";
+    }
+    return banner;
+}
+
+export { getBannerUrl };

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 // function for fetching the steam banner url
 function getBannerUrl(data) {
     var banner;
@@ -14,4 +16,33 @@ function getBannerUrl(data) {
     return banner;
 }
 
-export { getBannerUrl };
+function getGamePageUrl(data) {
+    var gamePage;
+    if(data.steamId != null && data.steamId != ""){
+        var id = data.steamId;
+        var title = data.title.replace(/ /g,"_").replace(/'/g, '');
+        gamePage = "https://store.steampowered.com/app/"+id+"/"+title+"/";
+    }else{
+        var title = data.title.toLowerCase().replace(/ /g,"-").replace(/'/g, '');
+        gamePage = "https://store.epicgames.com/en-US/p/"+title;
+    }
+    return gamePage;
+}
+
+async function getGames() {
+    const request = 'https://sheets.googleapis.com/v4/spreadsheets/1gbykEEXRHrIWTfl6gPrcxXjGZ6BndlAUxWrRcyHIp68/values/A2:K?key='+import.meta.env.VITE_API_KEY
+    const { data } = await axios.get(request);
+    var input = data.values
+    const keys = ["title", "completion", "date", "hours", "genre", "rating", "reccomend", "return", "steamId", "steamIcon", "notes"];
+    var games = input.reduce(function(acc, cur, i) {
+        var test = cur.reduce(function(acc, cur, i) {
+        acc[keys[i]] = cur;
+        return acc;
+        }, {});
+        acc[i] = test;
+        return acc;
+    }, []);
+    return games;
+}
+
+export { getBannerUrl, getGamePageUrl, getGames };

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -29,6 +29,19 @@ function getGamePageUrl(data) {
     return gamePage;
 }
 
+function getIconUrl(data) {
+    var icon;
+    if(data.steamIcon != null && data.steamIcon != ""){
+        var id = data.steamId;
+        var hash = data.steamIcon;
+        icon = "http://media.steampowered.com/steamcommunity/public/images/apps/"+id+"/"+hash+".jpg";
+    }else{
+        var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
+        icon = "/game_assets/icons/"+title+"_icon.png";
+    }
+    return icon;
+}
+
 async function getGames() {
     const request = 'https://sheets.googleapis.com/v4/spreadsheets/1gbykEEXRHrIWTfl6gPrcxXjGZ6BndlAUxWrRcyHIp68/values/A2:K?key='+import.meta.env.VITE_API_KEY
     const { data } = await axios.get(request);
@@ -45,4 +58,4 @@ async function getGames() {
     return games;
 }
 
-export { getBannerUrl, getGamePageUrl, getGames };
+export { getBannerUrl, getGamePageUrl, getIconUrl, getGames };

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -3,11 +3,18 @@ import axios from "axios";
 // function for fetching the steam banner url
 function getBannerUrl(data) {
     var banner;
+    console.log(data);
     
     // if there's a steam id, then fetch the banner image from steam
     if(data.steamId != null && data.steamId != ""){
-        var id = data.steamId;
-        banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
+        if(data.banner_hash != null && data.banner_hash != ""){
+            var id = data.steamId;
+            var hash = data.banner_hash;
+            banner = "https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/"+id+"/"+hash+"/header.jpg"; 
+        }else{
+            var id = data.steamId;
+            banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
+        }
     }else{
         // if it's not a steam game, grab the image locally
         var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
@@ -43,10 +50,10 @@ function getIconUrl(data) {
 }
 
 async function getGames() {
-    const request = 'https://sheets.googleapis.com/v4/spreadsheets/1gbykEEXRHrIWTfl6gPrcxXjGZ6BndlAUxWrRcyHIp68/values/A2:K?key='+import.meta.env.VITE_API_KEY
+    const request = 'https://sheets.googleapis.com/v4/spreadsheets/1gbykEEXRHrIWTfl6gPrcxXjGZ6BndlAUxWrRcyHIp68/values/A2:L?key='+import.meta.env.VITE_API_KEY
     const { data } = await axios.get(request);
     var input = data.values
-    const keys = ["title", "completion", "date", "hours", "genre", "rating", "reccomend", "return", "steamId", "steamIcon", "notes"];
+    const keys = ["title", "completion", "date", "hours", "genre", "rating", "reccomend", "return", "steamId", "steamIcon", "notes", "banner_hash"];
     var games = input.reduce(function(acc, cur, i) {
         var test = cur.reduce(function(acc, cur, i) {
         acc[keys[i]] = cur;

--- a/src/views/GameStatsView.vue
+++ b/src/views/GameStatsView.vue
@@ -30,7 +30,9 @@
                     </p-card>
                     <p-card class="shadow-8 mt-5" style="background:rgba(0, 0, 0, 0.4);">
                         <template #header>
-                            <p-image :src="getBannerUrl(topPlayedGame)" width="460"></p-image>
+                            <div v-for="item, index in topPlayedGame" v-bind:key="item.title">
+                                <p-image :src="getBannerUrl(item)" width="460"></p-image>
+                            </div>
                         </template>
                         <template #title>
                             <span class="flex text-4xl">
@@ -38,22 +40,22 @@
                             </span>
                         </template>
                         <template #content>
-                            <div class="flex flex-row justify-content-start align-items-center">
+                            <div v-for="item, index in topPlayedGame" v-bind:key="item.title" class="flex flex-row justify-content-start align-items-center">
                                 <div class="flex flex-row justify-content-center align-items-center">
                                     <div class="flex flex-column justify-content-center align-items-center mr-3">
                                         <div class="mr-0">
-                                            <p-image :src="getIconUrl(topPlayedGame)" width="32"></p-image>
+                                            <p-image :src="getIconUrl(item)" width="32"></p-image>
                                         </div>
                                     </div>
                                     <div class="flex flex-column justify-content-center">
                                         <div class="flex flex-row">
                                             <span class="flex text-2xl">
-                                                {{ topPlayedGame.title }}
+                                                {{ item.title }}
                                             </span>
                                         </div>
                                         <div class="flex flex-row mt-1">
                                             <span class="flex text-lg">
-                                                {{ topPlayedGame.hours }} hours
+                                                {{ item.hours }} hours
                                             </span>
                                         </div>
                                     </div>
@@ -160,6 +162,7 @@
 // Completed this year table? Maybe better on other page
 import axios from "axios";
 import Gradient from "javascript-color-gradient";
+import { getBannerUrl, getIconUrl, getGames } from "@/scripts/utils";
 export default {
     name: "GameStatsView",
     components: {
@@ -201,24 +204,13 @@ export default {
             this.currentGenre = "All";
             this.genreRatings["All"] = [0,0,0,0,0,0,0,0,0,0];
             this.topFiveGenres = [];
-            this.topPlayedGame = {};
+            this.topPlayedGame = [];
             this.loading = true;
             this.games = null;
             var totalGamesWithGenre = 0;
             this.totalPlaytime = 0;
             this.topTenPlaytime = [];
-            const request = 'https://sheets.googleapis.com/v4/spreadsheets/1gbykEEXRHrIWTfl6gPrcxXjGZ6BndlAUxWrRcyHIp68/values/A2:K?key='+import.meta.env.VITE_API_KEY
-            const { data } = await axios.get(request);
-            var input = data.values
-            const keys = ["title", "completion", "date", "hours", "genre", "rating", "reccomend", "return", "steamId", "steamIcon", "notes"];
-            this.games = input.reduce(function(acc, cur, i) {
-                var test = cur.reduce(function(acc, cur, i) {
-                acc[keys[i]] = cur;
-                return acc;
-                }, {});
-                acc[i] = test;
-                return acc;
-            }, []);
+            this.games = await getGames();
             this.loading = false;
             var genreArr = [];
             this.games.forEach((item) => {
@@ -274,8 +266,7 @@ export default {
             this.totalPlaytime = Math.round(this.totalPlaytime * 10) / 10
 
             this.topTenPlaytime.sort((a,b) => Number(b.hours) - Number(a.hours));
-            console.log(this.topTenPlaytime);
-            this.topPlayedGame = this.topTenPlaytime[0];
+            this.topPlayedGame.push(this.topTenPlaytime[0]);
             this.topTenPlaytime.shift();
             
             var sortable = Object.entries(this.genres)
@@ -538,29 +529,8 @@ export default {
                 },
             }
         }, 
-        getIconUrl(data) {
-            var icon;
-            if(data.steamId != null && data.steamId != ""){
-                var id = data.steamId;
-                var hash = data.steamIcon;
-                icon = "http://media.steampowered.com/steamcommunity/public/images/apps/"+id+"/"+hash+".jpg";
-            }else{
-                var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-                icon = "/game_assets/icons/"+title+"_icon.png";
-            }
-            return icon;
-        },
-        getBannerUrl(data) {
-            var banner;
-            if(data.steamId != null && data.steamId != ""){
-                var id = data.steamId;
-                banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
-            }else{
-                var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-                banner = "/game_assets/banners/"+title+"_banner.png";
-            }
-            return banner;
-        },
+        getIconUrl,
+        getBannerUrl,
         formatTags(value) {
             return value.split(", ");
         },

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -23,6 +23,7 @@ import { FilterMatchMode, FilterOperator } from '@primevue/core/api'
 import GameTable from "@/components/GameTable.vue";
 import CurrentlyPlaying from "@/components/CurrentlyPlaying.vue";
 import BacklogTable from "@/components/BacklogTable.vue";
+import { getBannerUrl, getGamePageUrl, getIconUrl, getGames } from "@/scripts/utils";
 
 export default {
   name: "GameView",
@@ -54,18 +55,7 @@ export default {
       this.games = null;
       this.currentlyPlaying = [];
       this.backlog = [];
-      const request = 'https://sheets.googleapis.com/v4/spreadsheets/1gbykEEXRHrIWTfl6gPrcxXjGZ6BndlAUxWrRcyHIp68/values/A2:K?key='+import.meta.env.VITE_API_KEY
-      const { data } = await axios.get(request);
-      var input = data.values
-      const keys = ["title", "completion", "date", "hours", "genre", "rating", "reccomend", "return", "steamId", "steamIcon", "notes"];
-      this.games = input.reduce(function(acc, cur, i) {
-        var test = cur.reduce(function(acc, cur, i) {
-          acc[keys[i]] = cur;
-          return acc;
-        }, {});
-        acc[i] = test;
-        return acc;
-      }, []);
+      this.games = await getGames();
       this.loading = false;
       this.games.forEach((item) => {
         if (item.completion == "In Progress") {
@@ -106,23 +96,8 @@ export default {
         
       }
     },
-    getIconUrl(data) {
-      var icon;
-      if(data.steamIcon != ""){
-        var id = data.steamId;
-        var hash = data.steamIcon;
-        icon = "http://media.steampowered.com/steamcommunity/public/images/apps/"+id+"/"+hash+".jpg";
-      }else{
-        var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-        icon = "/game_assets/icons/"+title+"_icon.png";
-      }
-      return icon;
-    },
-    getBannerUrl(data) {
-      var id = data.steamId;
-      var banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
-      return banner;
-    }
+    getIconUrl,
+    getBannerUrl
   },
   beforeMount() {
     this.getGames();

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -63,7 +63,7 @@
   // TODO: Make images links/add more details (playtime) to timeline
   // TODO: Add little icon/banner that shows 100% completion
   import axios from "axios";
-  import { getBannerUrl } from "@/scripts/utils";
+  import { getBannerUrl, getGamePageUrl, getGames } from "@/scripts/utils";
   
   export default {
     name: "Timeline",
@@ -73,8 +73,6 @@
       return {
         componentKey: 0,
         games: null,
-        currentlyPlaying: [],
-        backlog: [],
         filters: null,
         statuses: ['Backlog', 'Finished', '100%', 'Abandoned', 'In Progress'],
         ratings: ['Bad', 'Ok', 'Good', 'Great', 'Love'],
@@ -187,23 +185,11 @@
     mounted() {
     },
     methods: {
+      // this getGames function is different because it divides the games according to years they were beaten
       async getGames() {
         this.loading = true;
-        this.games = null;
-        this.currentlyPlaying = [];
-        this.backlog = [];
-        const request = 'https://sheets.googleapis.com/v4/spreadsheets/1gbykEEXRHrIWTfl6gPrcxXjGZ6BndlAUxWrRcyHIp68/values/A2:K?key='+import.meta.env.VITE_API_KEY
-        const { data } = await axios.get(request);
-        var input = data.values
-        const keys = ["title", "completion", "date", "hours", "genre", "rating", "reccomend", "return", "steamId", "steamIcon", "notes"];
-        this.games = input.reduce(function(acc, cur, i) {
-          var test = cur.reduce(function(acc, cur, i) {
-            acc[keys[i]] = cur;
-            return acc;
-          }, {});
-          acc[i] = test;
-          return acc;
-        }, []);
+        this.games = await getGames();
+        console.log(this.games);
         this.games.forEach((item) => {
           if(item.date){
             this.years.forEach((year) => {
@@ -235,11 +221,6 @@
                 }
               }
             })
-          }
-          if (item.completion == "In Progress") {
-            this.currentlyPlaying.push(item)
-          }else if (item.completion == "Backlog") {
-            this.backlog.push(item)
           }
         });
         var swap = false;
@@ -298,18 +279,7 @@
         return icon;
       },
       getBannerUrl,
-      getGamePageUrl(data) {
-        var gamePage;
-        if(data.steamId != null && data.steamId != ""){
-          var id = data.steamId;
-          var title = data.title.replace(/ /g,"_").replace(/'/g, '');
-          gamePage = "https://store.steampowered.com/app/"+id+"/"+title+"/";
-        }else{
-          var title = data.title.toLowerCase().replace(/ /g,"-").replace(/'/g, '');
-          gamePage = "https://store.epicgames.com/en-US/p/"+title;
-        }
-        return gamePage;
-      },
+      getGamePageUrl,
       compareDates( a, b ) {
         const firstDate = new Date(a.date);
         const secondDate = new Date(b.date)

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -63,6 +63,7 @@
   // TODO: Make images links/add more details (playtime) to timeline
   // TODO: Add little icon/banner that shows 100% completion
   import axios from "axios";
+  import { getBannerUrl } from "@/scripts/utils";
   
   export default {
     name: "Timeline",
@@ -296,17 +297,7 @@
         }
         return icon;
       },
-      getBannerUrl(data) {
-        var banner;
-        if(data.steamId != null && data.steamId != ""){
-          var id = data.steamId;
-          banner = "https://cdn.akamai.steamstatic.com/steam/apps/"+id+"/header.jpg";
-        }else{
-          var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-          banner = "/game_assets/banners/"+title+"_banner.png";
-        }
-        return banner;
-      },
+      getBannerUrl,
       getGamePageUrl(data) {
         var gamePage;
         if(data.steamId != null && data.steamId != ""){

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -189,7 +189,6 @@
       async getGames() {
         this.loading = true;
         this.games = await getGames();
-        console.log(this.games);
         this.games.forEach((item) => {
           if(item.date){
             this.years.forEach((year) => {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -63,7 +63,7 @@
   // TODO: Make images links/add more details (playtime) to timeline
   // TODO: Add little icon/banner that shows 100% completion
   import axios from "axios";
-  import { getBannerUrl, getGamePageUrl, getGames } from "@/scripts/utils";
+  import { getBannerUrl, getGamePageUrl, getIconUrl, getGames } from "@/scripts/utils";
   
   export default {
     name: "Timeline",
@@ -265,18 +265,7 @@
           
         }
       },
-      getIconUrl(data) {
-        var icon;
-        if(data.steamId != null && data.steamId != ""){
-          var id = data.steamId;
-          var hash = data.steamIcon;
-          icon = "http://media.steampowered.com/steamcommunity/public/images/apps/"+id+"/"+hash+".jpg";
-        }else{
-          var title = data.title.toLowerCase().replace(/ /g,"_").replace(/'/g, '');
-          icon = "/game_assets/icons/"+title+"_icon.png";
-        }
-        return icon;
-      },
+      getIconUrl,
       getBannerUrl,
       getGamePageUrl,
       compareDates( a, b ) {


### PR DESCRIPTION
Steam updated how they host banner images and now they include a random hash or id of some kind in the url that I don't get in the steam data I fetch. They also are only doing this for new game moving forward, so I can't just switch completely the the new way. I added a workaround here where if I manually paste a banner hash in my spreadsheet, it will use it to fetch the image the new way. Also moved some functions into a helper utils script and fixed a bug on the stats page